### PR TITLE
Add permissive CORS header to HTTP server

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -186,6 +186,7 @@ fn serve_data(stream: &mut TcpStream, data: &[u8], content_type: &str) {
         "HTTP/1.1 200 OK",
         &format!("Content-Type: {}", content_type),
         &format!("Content-Length: {}", data.len()),
+        "Access-Control-Allow-Origin: *",
         "Connection: close",
         "",
         "",


### PR DESCRIPTION
Addition of the [`Access-Control-Allow-Origin: *`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header/value would signal to browsers that cross-origin requests should be allowed.

For context, I ran into CORS errors when running this server locally at `http://localhost:8080` and attempting to load images while my [Leaflet](https://leafletjs.com/) frontend was being served from `http://localhost:63340`. My browser (Chrome) disallowed the cross-origin requests.

Thank you for writing this software!