### PR TITLE
[audit] xml-rs → quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,9 +413,9 @@ dependencies = [
  "osmpbf",
  "owning_ref",
  "png",
+ "quick-xml",
  "stb_truetype",
  "tini",
- "xml-rs",
 ]
 
 [[package]]
@@ -519,9 +528,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ indexmap = "*"
 memmap = "*"
 owning_ref = "*"
 png = "*"
+quick-xml = "*"
 stb_truetype = "*"
 tini = "*"
-xml-rs = "*"
 
 [dependencies.osmpbf]
 version = "*"


### PR DESCRIPTION
`xml-rs` [is not maintained](https://rustsec.org/advisories/RUSTSEC-2022-0048) anymore. It is apparently [currently being](https://github.com/netvl/xml-rs/issues/221#issuecomment-1364144356) transferred, but even if that happens (which is not a given), `xml-rs` still appears to have a large backlog of unresolved issues. Looks like it's time to switch.

I found two crates that are actively maintained and can do SAX parsing:
  * [quick-xml](https://github.com/tafia/quick-xml). Clean codebase, no `unsafe`, lots of tests, lots of recent commits. Lots of dependencies as well, but fortunately all of them are optional except `memchr`, which I guess is OK. The API is similar to `xml-rs`, so migration is mostly straightforward.
  * [xmlparser](https://github.com/RazrFalcon/xmlparser). An absolute gem of a library: no dependencies at all, small and clean codebase, no `unsafe`. Unfortunately, the API doesn't group attributes together (the current geodata importer [relies](https://github.com/dfyz/osm-renderer/blob/87266a44464447be4951d4c244a7f85bc054e59c/src/geodata/importer.rs#L372) on that), and I don't want to make too invasive changes when switching.

So, `quick-xml` it is (for now). By the way, it really lives up to its name: importing Serbia now takes **01:08** minutes on my laptop, while it used to take **02:51** minutes.