### PR TITLE
fix build for `cargo -F perf-stats`

### DIFF
--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -44,7 +44,7 @@ pub fn run_server(
         reader: GeodataReader::load(geodata_file).context("Failed to load the geodata file")?,
         drawer: Drawer::new(&base_path),
         osm_ids,
-        perf_stats: Mutex::new(PerfStats),
+        perf_stats: Mutex::new(PerfStats::new()),
     });
 
     let thread_count =

--- a/src/perf_stats/dummy_impl.rs
+++ b/src/perf_stats/dummy_impl.rs
@@ -3,6 +3,10 @@ pub struct PerfStats;
 pub struct Measurer;
 
 impl PerfStats {
+    pub fn new() -> PerfStats {
+        PerfStats{}
+    }
+
     pub fn to_html(&self) -> String {
         unimplemented!("This dummy implementation doesn't support HTML rendering")
     }

--- a/src/perf_stats/real_impl.rs
+++ b/src/perf_stats/real_impl.rs
@@ -116,8 +116,14 @@ pub struct PerfStats {
 }
 
 impl PerfStats {
+    pub fn new() -> PerfStats {
+        PerfStats {
+            stats_by_zoom: BTreeMap::new(),
+        }
+    }
+
     fn add_tile_stats(&mut self, tile_stats: TilePerfStats) {
-        let mut zoom_stats = self.stats_by_zoom.entry(tile_stats.zoom).or_default();
+        let zoom_stats = self.stats_by_zoom.entry(tile_stats.zoom).or_default();
         zoom_stats.root_element.add(&tile_stats.root_element);
         zoom_stats.count += 1;
     }


### PR DESCRIPTION
fixies this error:

src\http_server.rs:47:32

         perf_stats: Mutex::new(PerfStats),
                                ^^^^^^^^^ help: use struct literal syntax instead: `PerfStats { stats_by_zoom: val }`